### PR TITLE
Revert "feat: Add more margin between icon and score on shull popup"

### DIFF
--- a/eznashdb/templates/eznashdb/includes/shul_popup.html
+++ b/eznashdb/templates/eznashdb/includes/shul_popup.html
@@ -23,14 +23,14 @@
                                 <div class="col-12">
                                     <div class="row gx-0 ps-3">
                                         <div class="col-12 mb-2">
-                                            <span style="width:20px;" class="d-inline-block text-center me-2">
-                                                <i class="fa-solid fa-up-right-and-down-left-from-center"></i>
+                                            <span style="width:20px;" class="d-inline-block text-center">
+                                                <i class="fa-solid fa-up-right-and-down-left-from-center me-1"></i>
                                             </span>
                                             <span>{{ room.get_relative_size_display|safe|default:"<kbd class='fw-bold'>?</kbd> -" }}</span>
                                         </div>
                                         <div class="col-12 mb-2">
-                                            <span style="width:20px;" class="d-inline-block text-center me-2">
-                                                <i class="fa-solid fa-eye"></i>
+                                            <span style="width:20px;" class="d-inline-block text-center">
+                                                <i class="fa-solid fa-eye me-1"></i>
                                             </span>
                                             <span>
                                             {{ room.get_see_hear_score_display|safe|default:"<kbd class='fw-bold'>?</kbd> - " }}</span>


### PR DESCRIPTION
This reverts commit 835c7f1e4903c43dd5d393968e163535ddbdf24a.
