### PR TITLE
fix: Resolve libldap dependency issue in worker-service Dockerfile

### DIFF
--- a/worker-service/Dockerfile
+++ b/worker-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim-bookworm
 
 # Install system dependencies and PostgreSQL 15 client
 RUN apt-get update && \
@@ -9,6 +9,7 @@ RUN apt-get update && \
     curl \
     unzip \
     nano \
+    libldap-2.5-0 \
     && curl https://rclone.org/install.sh | bash \
     && ln -s /usr/bin/python3 /usr/bin/python \
     # Add PostgreSQL apt repository for version 15


### PR DESCRIPTION
Pin base image to bookworm and explicitly install libldap-2.5-0 to fix
PostgreSQL client 15 installation dependency conflict during CD deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
