### PR TITLE
fix: Set Python interpreter path in devcontainer to resolve import warnings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,6 +28,7 @@
 				"anthropic.claude-code"
 			],
 			"settings": {
+				"python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
 				"python.venvPath": ".",
 				"[python]": {
 					"editor.formatOnSave": true,


### PR DESCRIPTION
Configure VS Code to use the .venv Python interpreter to fix warnings
about missing third-party packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
