### PR TITLE
fix: Mount gh config to persist GitHub CLI authentication

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,8 @@
 		5432
 	],
 	"mounts": [
-		"source=${localEnv:HOME}/.config/rclone,target=/home/docker/.config/rclone,type=bind,consistency=cached"
+		"source=${localEnv:HOME}/.config/rclone,target=/home/docker/.config/rclone,type=bind,consistency=cached",
+		"source=${localEnv:HOME}/.config/gh,target=/home/docker/.config/gh,type=bind,consistency=cached"
 	],
 	"customizations": {
 		"vscode": {


### PR DESCRIPTION
Adds ~/.config/gh mount to devcontainer to persist GitHub CLI oauth tokens
across container rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
