### PR TITLE
style: Add text-wrap pretty to address input help text

### DIFF
--- a/assets/components/AddressInput.js
+++ b/assets/components/AddressInput.js
@@ -90,7 +90,7 @@ export const AddressInput = ({
 
   return (
     <div className={isModal ? "d-flex flex-column h-100" : ""}>
-      <div className="text-muted small mb-2">
+      <div className="text-muted small mb-2" style={{ textWrap: "pretty" }}>
         Can't find your shul? Search city or street, then drag map
       </div>
       <div


### PR DESCRIPTION
Improves line breaking for the help text by using text-wrap: pretty,
creating more balanced line breaks when wrapping across multiple lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
