### PR TITLE
feat: set maxZoom to 15 to keep clusters visible after refresh

### DIFF
--- a/eznashdb/templates/eznashdb/shuls.html
+++ b/eznashdb/templates/eznashdb/shuls.html
@@ -311,6 +311,7 @@
                     scrollWheelZoom: true,
                     worldCopyJump: true,
                     minZoom: 1,
+                    maxZoom: 15,
                     zoomControl: false,
                 });
 


### PR DESCRIPTION
Prevents zooming in too far, ensuring that when users save a shul and
refresh (losing the exact pin), the cluster with jitter and offset
remains visible on screen.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
