### PR TITLE
fix: Send origin on cross-origin requests

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -50,6 +50,8 @@ CSRF_TRUSTED_ORIGINS = [
 # Trust X-Forwarded-Proto header from proxy for HTTPS detection
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
+SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
+
 # Security headers for production
 if DJANGO_ENV == "prod":
     SECURE_SSL_REDIRECT = True


### PR DESCRIPTION
why
So OSM tile servers can verify the Referer. Prevents 403r
errors on the map
